### PR TITLE
Add tests for pending transactions

### DIFF
--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -166,6 +166,36 @@ paths:
               schema:
                 $ref: '#/components/schemas/Storage'
 
+  /transactions/pending:
+    parameters:
+      - $ref: '#/components/parameters/RawInQuery'
+      - $ref: '#/components/parameters/ExpandedTxInQuery'
+    get:
+      tags:
+        - Transactions
+      summary: Retrieve pending transactions
+      description: |
+        represents the current transaction pool
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:                        
+                  oneOf:
+                    - allOf:
+                      - $ref: '#/components/schemas/Tx'
+                      properties:
+                        meta:
+                          required: false
+                          $ref: '#/components/schemas/TxMeta'
+                    - allOf:
+                      - $ref: '#/components/schemas/RawTx'
+                      description: raw transaction
+                example: ['0x4de71f2d588aa8a1ea00fe8312d92966da424d9939a511fc0be81e65fad52af8']
+
   /transactions/{id}:
     parameters:
       - $ref: '#/components/parameters/TxIDInPath'
@@ -1411,5 +1441,14 @@ components:
       required: false
       description: |
         whether to return tx, even it's pending
+      schema:
+        type: boolean
+
+    ExpandedTxInQuery:
+      name: expanded
+      in: query
+      required: false
+      description: |
+        whether to return tx details
       schema:
         type: boolean

--- a/api/transactions/transactions.go
+++ b/api/transactions/transactions.go
@@ -226,18 +226,18 @@ func (t *Transactions) getAllTxIDsFromTxpool() ([]string, error) {
 
 func (t *Transactions) handleGetAllTxIDsFromTxPool(w http.ResponseWriter, req *http.Request) error {
     raw := req.URL.Query().Get("raw")
-    detailed := req.URL.Query().Get("detailed")
+    expanded := req.URL.Query().Get("expanded")
 
     if raw != "" && raw != "false" && raw != "true" {
         return utils.BadRequest(errors.New("raw should be boolean"))
     }
 
-    if detailed != "" && detailed != "false" && detailed != "true" {
-        return utils.BadRequest(errors.New("detailed should be boolean"))
+    if expanded != "" && expanded != "false" && expanded != "true" {
+        return utils.BadRequest(errors.New("expanded should be boolean"))
     }
 
     rawBool := raw == "true"
-    detailedBool := detailed == "true"
+    expandedBool := expanded == "true"
 
     txs := t.pool.Executables()
     if rawBool {
@@ -250,7 +250,7 @@ func (t *Transactions) handleGetAllTxIDsFromTxPool(w http.ResponseWriter, req *h
             rawTxs = append(rawTxs, RawTx{hexutil.Encode(raw)})
         }
         return utils.WriteJSON(w, rawTxs)
-    } else if detailedBool {
+    } else if expandedBool {
         detailedTxs := make([]*Transaction, 0, len(txs))
         for _, tx := range txs {
             detailedTxs = append(detailedTxs, convertTransaction(tx, nil))

--- a/api/transactions/transactions.go
+++ b/api/transactions/transactions.go
@@ -269,7 +269,7 @@ func (t *Transactions) Mount(root *mux.Router, pathPrefix string) {
 	sub := root.PathPrefix(pathPrefix).Subrouter()
 
 	sub.Path("").Methods("POST").HandlerFunc(utils.WrapHandlerFunc(t.handleSendTransaction))
+	sub.Path("/pending").Methods("GET").HandlerFunc(utils.WrapHandlerFunc(t.handleGetAllTxIDsFromTxPool))
 	sub.Path("/{id}").Methods("GET").HandlerFunc(utils.WrapHandlerFunc(t.handleGetTransactionByID))
 	sub.Path("/{id}/receipt").Methods("GET").HandlerFunc(utils.WrapHandlerFunc(t.handleGetTransactionReceiptByID))
-    	sub.Path("/txpool/txids").Methods("GET").HandlerFunc(utils.WrapHandlerFunc(t.handleGetAllTxIDsFromTxPool))
 }

--- a/api/transactions/transactions_test.go
+++ b/api/transactions/transactions_test.go
@@ -41,6 +41,7 @@ func TestTransaction(t *testing.T) {
 	getTx(t)
 	getTxReceipt(t)
 	senTx(t)
+	getTxPending(t)
 }
 
 func getTx(t *testing.T) {
@@ -71,6 +72,47 @@ func getTxReceipt(t *testing.T) {
 	}
 	assert.Equal(t, uint64(receipt.GasUsed), transaction.Gas(), "gas should be equal")
 }
+
+func getTxPending(t *testing.T) {
+	var blockRef = tx.NewBlockRef(0)
+	var chainTag = repo.ChainTag()
+	var expiration = uint32(10)
+	var gas = uint64(21000)
+
+	tx := new(tx.Builder).
+		BlockRef(blockRef).
+		ChainTag(chainTag).
+		Expiration(expiration).
+		Gas(gas).
+		Build()
+	sig, err := crypto.Sign(tx.SigningHash().Bytes(), genesis.DevAccounts()[0].PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx = tx.WithSignature(sig)
+	rlpTx, err := rlp.EncodeToBytes(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resAdded := httpPost(t, ts.URL+"/transactions", transactions.RawTx{Raw: hexutil.Encode(rlpTx)})
+	var txObj map[string]string
+	if err = json.Unmarshal(resAdded, &txObj); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	res := httpGet(t, ts.URL+"/transactions/pending")
+	t.Logf("Res: %s\n", res)
+	var poolIds []string
+	if err := json.Unmarshal(res, &poolIds); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%s\n", poolIds[0])
+	assert.Contains(t, poolIds, txObj["id"], "should contain new transaction id")
+}
+
 
 func senTx(t *testing.T) {
 	var blockRef = tx.NewBlockRef(0)
@@ -204,3 +246,4 @@ func httpGet(t *testing.T, url string) []byte {
 	}
 	return r
 }
+

--- a/api/transactions/transactions_test.go
+++ b/api/transactions/transactions_test.go
@@ -104,12 +104,10 @@ func getTxPending(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	res := httpGet(t, ts.URL+"/transactions/pending")
-	t.Logf("Res: %s\n", res)
 	var poolIds []string
 	if err := json.Unmarshal(res, &poolIds); err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("%s\n", poolIds[0])
 	assert.Contains(t, poolIds, txObj["id"], "should contain new transaction id")
 }
 


### PR DESCRIPTION
- This will add a test to check if a transaction id is in the pending pool. It is not covering the flags at the moment.
- Additionally it changes the route from `/transactions/txpool/txids` to `/transactions/pending` to be consistent with the pending option in the `/ transactions/{id}` wording.
- I am unsure if a subroute on transactions is the best approach because it can collide with the expectations of a transaction id. I also don't want to suggest a new scope at the root level, because it is a list of pending transactions.
- Added also documentation for the endpoint, in the process renamed `detailed` to `expanded` because thats the current name for the flag of `/blocks/best?expanded=true` which returns transaction details. Using a consistent wording improves user experience.